### PR TITLE
Finished refactor of JakanUsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-    "presets": [
-        "@babel/preset-typescript"
-    ]
-}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ What can you expect?
     `Powered by axios-cache-interceptor`
 
 -   Platform-agnostic:  
-    We use Parcel and Babel to build the library with support for most browsers and node environments.
-    This includes automatic polyfills and compatibility with CommonJS and ESM.
+    We use Parcel to build the library with support for most browsers and node environments.
+    This includes compatibility with CommonJS, and ESM.
     We are also limiting ourselves to ES5 syntax for maximum compatibility.
 
 -   Typescript first  

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@
 module.exports = {
     preset: "ts-jest",
     testEnvironment: "node",
+    testTimeout: 20000,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "redis": "^4.3.0"
             },
             "devDependencies": {
-                "@babel/preset-typescript": "^7.18.6",
                 "@parcel/packager-ts": "^2.8.2",
                 "@parcel/transformer-typescript-tsc": "^2.8.2",
                 "@parcel/transformer-typescript-types": "^2.8.2",
@@ -147,18 +146,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-            "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.20.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
@@ -202,27 +189,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
-        "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.7.tgz",
-            "integrity": "sha512-LtoWbDXOaidEf50hmdDqn9g8VEzsorMexoWMQdQODbvmqYmaF23pBP5VNPAGIFHsFQCIeKokDiz3CH5Y2jlY6w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.18.6",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-member-expression-to-functions": "^7.20.7",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/helper-replace-supers": "^7.20.7",
-                "@babel/helper-split-export-declaration": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
         "node_modules/@babel/helper-environment-visitor": {
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
@@ -252,18 +218,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-            "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -300,40 +254,11 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-            "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
             "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-replace-supers": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-            "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-member-expression-to-functions": "^7.20.7",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/template": "^7.20.7",
-                "@babel/traverse": "^7.20.7",
-                "@babel/types": "^7.20.7"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -660,40 +585,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.19.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.7.tgz",
-            "integrity": "sha512-m3wVKEvf6SoszD8pu4NZz3PvfKRCMgk6D6d0Qi9hNnlM5M6CFS92EgF4EiHVLKbU0r/r7ty1hg7NPZwE7WRbYw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.20.7",
-                "@babel/helper-plugin-utils": "^7.20.2",
-                "@babel/plugin-syntax-typescript": "^7.20.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-typescript": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
-            "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.18.6",
-                "@babel/helper-validator-option": "^7.18.6",
-                "@babel/plugin-transform-typescript": "^7.18.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -8558,15 +8449,6 @@
                 "jsesc": "^2.5.1"
             }
         },
-        "@babel/helper-annotate-as-pure": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-            "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.18.6"
-            }
-        },
         "@babel/helper-compilation-targets": {
             "version": "7.20.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
@@ -8603,21 +8485,6 @@
                 }
             }
         },
-        "@babel/helper-create-class-features-plugin": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.7.tgz",
-            "integrity": "sha512-LtoWbDXOaidEf50hmdDqn9g8VEzsorMexoWMQdQODbvmqYmaF23pBP5VNPAGIFHsFQCIeKokDiz3CH5Y2jlY6w==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.18.6",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-member-expression-to-functions": "^7.20.7",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/helper-replace-supers": "^7.20.7",
-                "@babel/helper-split-export-declaration": "^7.18.6"
-            }
-        },
         "@babel/helper-environment-visitor": {
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
@@ -8641,15 +8508,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
-            }
-        },
-        "@babel/helper-member-expression-to-functions": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-            "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.20.7"
             }
         },
         "@babel/helper-module-imports": {
@@ -8677,34 +8535,11 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "@babel/helper-optimise-call-expression": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-            "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.18.6"
-            }
-        },
         "@babel/helper-plugin-utils": {
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
             "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true
-        },
-        "@babel/helper-replace-supers": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-            "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-member-expression-to-functions": "^7.20.7",
-                "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/template": "^7.20.7",
-                "@babel/traverse": "^7.20.7",
-                "@babel/types": "^7.20.7"
-            }
         },
         "@babel/helper-simple-access": {
             "version": "7.20.2",
@@ -8946,28 +8781,6 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.19.0"
-            }
-        },
-        "@babel/plugin-transform-typescript": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.7.tgz",
-            "integrity": "sha512-m3wVKEvf6SoszD8pu4NZz3PvfKRCMgk6D6d0Qi9hNnlM5M6CFS92EgF4EiHVLKbU0r/r7ty1hg7NPZwE7WRbYw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.20.7",
-                "@babel/helper-plugin-utils": "^7.20.2",
-                "@babel/plugin-syntax-typescript": "^7.20.0"
-            }
-        },
-        "@babel/preset-typescript": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
-            "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.18.6",
-                "@babel/helper-validator-option": "^7.18.6",
-                "@babel/plugin-transform-typescript": "^7.18.6"
             }
         },
         "@babel/template": {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,21 @@
         "prebuild": "rimraf dist",
         "run": "npm build",
         "build": "parcel build",
-        "test": "jest",
-        "js-test": "node test.mjs"
+        "test": "jest"
     },
-    "keywords": ["jikan", "api", "wrapper", "mal", "typescript", "javascript", "node", "browser"],
+    "keywords": [
+        "jikan",
+        "api",
+        "wrapper",
+        "mal",
+        "typescript",
+        "javascript",
+        "node",
+        "browser"
+    ],
     "author": "Lamarcke",
     "license": "MIT",
     "devDependencies": {
-        "@babel/preset-typescript": "^7.18.6",
         "@parcel/packager-ts": "^2.8.2",
         "@parcel/transformer-typescript-tsc": "^2.8.2",
         "@parcel/transformer-typescript-types": "^2.8.2",
@@ -51,8 +58,5 @@
         "browser-or-node": "^2.0.0",
         "localforage": "^1.10.0",
         "redis": "^4.3.0"
-    },
-    "prettier": {
-        "tabWidth": 4
     }
 }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -10,6 +10,7 @@ import { type } from "os";
 
 class JakanClientBuilder implements JakanBuilder {
     private redisClient: RedisClientType | undefined;
+    // 15 minutes
     private cacheAge: number = 15 * 60 * 1000;
     private forage: unknown | undefined;
     private webStorage: Storage | undefined;

--- a/src/clients/misc/misc.ts
+++ b/src/clients/misc/misc.ts
@@ -3,7 +3,6 @@ import { BASE_JIKAN_URL } from "../../constants";
 import {
     JakanIDResponse,
     JakanQueryResponse,
-    JakanSeasonListResponse,
 } from "../../response/responseTypes";
 import {
     GenresQuery,
@@ -59,7 +58,7 @@ class JakanMisc extends JakanClient {
             return get;
         } catch (e: unknown) {
             if (e instanceof AxiosError) {
-                throw e
+                throw e;
             } else {
                 throw new JakanMiscError(
                     "An error unrelated to Jikan happened while making the request: " +
@@ -199,19 +198,18 @@ class JakanMisc extends JakanClient {
         }
     }
     /*
-     * This function is a bit different from the others, mainly because the
-     * /seasons endpoint is one of the few that have "data" as an array, but has no pagination info.
+     * The /seasons endpoint is one of the few that have "data" as an array, but no pagination info.
      */
     seasonList(
         when: SeasonListRequestWhen,
         query: SeasonListQuery
     ): Promise<JakanQueryResponse>;
     seasonList(when: SeasonListRequestWhen): Promise<JakanQueryResponse>;
-    seasonList(): Promise<JakanSeasonListResponse>;
+    seasonList(): Promise<JakanQueryResponse>;
     async seasonList(
         when?: SeasonListRequestWhen,
         query?: SeasonListQuery
-    ): Promise<JakanQueryResponse | JakanSeasonListResponse> {
+    ): Promise<JakanQueryResponse> {
         let request = "";
         if (when != undefined && typeof when == "string") {
             const endpointBase = `seasons/${when}`;
@@ -222,9 +220,7 @@ class JakanMisc extends JakanClient {
         }
 
         try {
-            const get = await this.makeRequest<
-                JakanQueryResponse | JakanSeasonListResponse
-            >(request);
+            const get = await this.makeRequest<JakanQueryResponse>(request);
             return get;
         } catch (e: unknown) {
             if (e instanceof AxiosError) {

--- a/src/clients/search/search.ts
+++ b/src/clients/search/search.ts
@@ -1,6 +1,6 @@
 import JakanClient from "../base";
 import {
-    QueryOrId,
+    SearchQueryOrId,
     AnimeSearchParameters,
     CharacterSearchParameters,
     PeopleSearchParameters,
@@ -9,7 +9,7 @@ import {
     MangaSearchParameters,
     ExtraCharactersInfo,
     ExtraPeopleInfo,
-    ExtraInfo,
+    SearchExtraInfo,
 } from "./searchTypes";
 import {
     JakanIDResponse,
@@ -36,7 +36,7 @@ class JakanSearch extends JakanClient {
     anime(query: string): Promise<JakanQueryResponse>;
     // Searches for an anime using either an id, a query, or a set of parameters.
     async anime(
-        queryOrId: QueryOrId<AnimeSearchParameters>,
+        queryOrId: SearchQueryOrId<AnimeSearchParameters>,
         extraInfo?: ExtraAnimeInfo
     ): Promise<JakanIDResponse | JakanQueryResponse> {
         return await this.prepareRequest<AnimeSearchParameters, ExtraAnimeInfo>(
@@ -52,7 +52,7 @@ class JakanSearch extends JakanClient {
     manga(query: string): Promise<JakanQueryResponse>;
     // Searches for a manga using either an id, a query, or a set of parameters.
     async manga(
-        queryOrId: QueryOrId<MangaSearchParameters>,
+        queryOrId: SearchQueryOrId<MangaSearchParameters>,
         extraInfo?: ExtraMangaInfo
     ): Promise<JakanQueryResponse | JakanIDResponse> {
         return await this.prepareRequest<MangaSearchParameters, ExtraMangaInfo>(
@@ -70,7 +70,7 @@ class JakanSearch extends JakanClient {
     characters(id: number): Promise<JakanIDResponse>;
     characters(query: string): Promise<JakanQueryResponse>;
     async characters(
-        queryOrId: QueryOrId<CharacterSearchParameters>,
+        queryOrId: SearchQueryOrId<CharacterSearchParameters>,
         extraInfo?: ExtraCharactersInfo
     ): Promise<JakanQueryResponse | JakanIDResponse> {
         return await this.prepareRequest<
@@ -84,7 +84,7 @@ class JakanSearch extends JakanClient {
     people(id: number): Promise<JakanIDResponse>;
     people(query: string): Promise<JakanQueryResponse>;
     async people(
-        queryOrId: QueryOrId<PeopleSearchParameters>,
+        queryOrId: SearchQueryOrId<PeopleSearchParameters>,
         extraInfo?: ExtraPeopleInfo
     ): Promise<JakanQueryResponse | JakanIDResponse> {
         return await this.prepareRequest<
@@ -93,9 +93,12 @@ class JakanSearch extends JakanClient {
         >(SearchMediaOptions.people, queryOrId, extraInfo);
     }
 
-    private async prepareRequest<T extends QueryOrId, E extends ExtraInfo>(
+    private async prepareRequest<
+        T extends SearchQueryOrId,
+        E extends SearchExtraInfo
+    >(
         media: string,
-        queryOrId: QueryOrId<T>,
+        queryOrId: SearchQueryOrId<T>,
         extraInfo?: E
     ): Promise<JakanIDResponse | JakanQueryResponse> {
         if (typeof queryOrId === "number") {
@@ -116,16 +119,18 @@ class JakanSearch extends JakanClient {
         id: number,
         extraInfo?: string
     ): Promise<JakanIDResponse> {
-        const request = this.idRequestBuilder(media, id, extraInfo);
+        const request = this.infoRequestBuilder(media, id, extraInfo);
         return await this.makeRequest<JakanIDResponse>(request);
     }
 
-    private async withQuery<T extends QueryOrId>(
+    private async withQuery<T extends SearchQueryOrId>(
         media: string,
         query: T
     ): Promise<JakanQueryResponse> {
         if (typeof query === "number") {
-            throw new JakanSearchError("Can't");
+            throw new JakanSearchError(
+                "It's not possible to use IDs with query requests."
+            );
         }
         const request = this.queryRequestBuilder(media, query);
         return await this.makeRequest<JakanQueryResponse>(request);

--- a/src/clients/search/searchTypes.ts
+++ b/src/clients/search/searchTypes.ts
@@ -116,7 +116,7 @@ type SearchRequestParameters =
  * This type determines which type of extra info is being used by a function.
  *
  */
-type ExtraInfo<
+type SearchExtraInfo<
     T extends SearchRequestExtraInfo | string = SearchRequestExtraInfo
 > = SearchRequestExtraInfo | string | T;
 
@@ -124,15 +124,13 @@ type ExtraInfo<
  * Type to determine if a search function is using query parameters (string | object) or a id (number).
  * Defaults to string if no type is specified.
  */
-type QueryOrId<T extends SearchRequestParameters | number | string = string> =
-    | SearchRequestParameters
-    | number
-    | string
-    | T;
+type SearchQueryOrId<
+    T extends SearchRequestParameters | number | string = string
+> = SearchRequestParameters | number | string | T;
 
 export type {
-    QueryOrId,
-    ExtraInfo,
+    SearchQueryOrId,
+    SearchExtraInfo,
     SearchRequestParameters,
     SearchRequestExtraInfo,
     AnimeSearchParameters,

--- a/src/clients/users/userConstants.ts
+++ b/src/clients/users/userConstants.ts
@@ -1,8 +1,8 @@
-enum UserExtraInfoOptions {
+enum UsersExtraInfoOptions {
     full = "full",
     statistics = "statistics",
     favorites = "favorites",
-    userupdates = "userupdates",
+    userUpdates = "userupdates",
     about = "about",
     history = "history",
     clubs = "clubs",
@@ -12,4 +12,11 @@ enum UserExtraInfoOptions {
     external = "external",
 }
 
-export type { UserExtraInfoOptions };
+enum UsersGenders {
+    any = "any",
+    male = "male",
+    female = "female",
+    nonbinary = "nonbinary",
+}
+
+export type { UsersExtraInfoOptions, UsersGenders };

--- a/src/clients/users/userTypes.ts
+++ b/src/clients/users/userTypes.ts
@@ -1,5 +1,15 @@
-import { UserExtraInfoOptions } from "./userConstants";
+import { UsersExtraInfoOptions, UsersGenders } from "./userConstants";
 
-type UserExtraInfo = keyof typeof UserExtraInfoOptions;
+interface UsersQuery {
+    q: string;
+    limit?: number;
+    page?: number;
+    gender?: keyof typeof UsersGenders;
+    location?: string;
+    minAge?: number;
+    maxAge?: number;
+}
 
-export type { UserExtraInfo };
+type UsersExtraInfo = keyof typeof UsersExtraInfoOptions;
+
+export type { UsersExtraInfo, UsersQuery };

--- a/src/clients/users/users.ts
+++ b/src/clients/users/users.ts
@@ -1,11 +1,66 @@
 import JakanClient from "../base";
 import { BASE_JIKAN_URL } from "../../constants";
+import {
+    JakanIDResponse,
+    JakanQueryResponse,
+} from "../../response/responseTypes";
+import { UsersExtraInfo, UsersQuery } from "./userTypes";
+import { AxiosError } from "axios";
 
-// A client responsible for communication with MAL official API for user related requests.
-// Please read the Jakan README for more info on how this works.
+// TODO: refactor to use Jikan user endpoints.
 class JakanUsers extends JakanClient {
     constructor() {
         super(BASE_JIKAN_URL);
+    }
+
+    async users(
+        username: string,
+        extraInfo?: UsersExtraInfo
+    ): Promise<JakanIDResponse> {
+        const endpointBase = "users";
+        const request = this.infoRequestBuilder(
+            endpointBase,
+            username,
+            extraInfo
+        );
+        try {
+            const get = await this.makeRequest<JakanIDResponse>(request);
+            return get;
+        } catch (e: unknown) {
+            if (e instanceof AxiosError) {
+                throw e;
+            } else {
+                throw new Error(
+                    "An error unrelated to Jikan happened while making the request: " +
+                        e
+                );
+            }
+        }
+    }
+
+    async usersSearch(
+        query?: UsersQuery | string | undefined
+    ): Promise<JakanQueryResponse> {
+        const endpointBase = "users";
+        let request = "";
+        if (query != undefined) {
+            request = this.queryRequestBuilder(endpointBase, query);
+        } else {
+            request = endpointBase;
+        }
+        try {
+            const get = await this.makeRequest<JakanQueryResponse>(request);
+            return get;
+        } catch (e: unknown) {
+            if (e instanceof AxiosError) {
+                throw e;
+            } else {
+                throw new Error(
+                    "An error unrelated to Jikan happened while making the request: " +
+                        e
+                );
+            }
+        }
     }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,16 +1,9 @@
-import {
-    JakanIDResponse,
-    JakanQueryResponse,
-    JakanSeasonListResponse,
-} from "./response/responseTypes";
+import { JakanIDResponse, JakanQueryResponse } from "./response/responseTypes";
 
 const BASE_JIKAN_URL = "https://api.jikan.moe/v4/";
 const BASE_MAL_URL = "https://api.myanimelist.net/v2/";
 
-type JakanResponse =
-    | JakanIDResponse
-    | JakanQueryResponse
-    | JakanSeasonListResponse;
+type JakanResponse = JakanIDResponse | JakanQueryResponse;
 
 export { BASE_JIKAN_URL, BASE_MAL_URL };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,38 @@ import { Jakan } from "./jakan";
 import JakanSearch from "./clients/search/search";
 import JakanUsers from "./clients/users/users";
 import JakanMisc from "./clients/misc/misc";
+import { JakanQueryResponse, JakanIDResponse } from "./response/responseTypes";
 import {
     AnimeSearchParameters,
     MangaSearchParameters,
+    CharacterSearchParameters,
+    PeopleSearchParameters,
 } from "./clients/search/searchTypes";
-import { ExtraAnimeInfo, ExtraMangaInfo } from "./clients/search/searchTypes";
+import {
+    ExtraAnimeInfo,
+    ExtraMangaInfo,
+    ExtraCharactersInfo,
+    ExtraPeopleInfo,
+} from "./clients/search/searchTypes";
+import { UsersExtraInfo, UsersQuery } from "./clients/users/userTypes";
 
 export default Jakan;
+// Client types
+export type { JakanSearch, JakanUsers, JakanMisc };
+// Search parameters
 export type {
-    JakanSearch,
-    JakanUsers,
-    JakanMisc,
     AnimeSearchParameters,
     MangaSearchParameters,
     ExtraAnimeInfo,
     ExtraMangaInfo,
+    ExtraCharactersInfo,
+    ExtraPeopleInfo,
 };
+// Misc parameters
+export type {};
+
+// User parameters
+export type { UsersExtraInfo, UsersQuery };
+
+// Response types
+export type { JakanIDResponse, JakanQueryResponse };

--- a/src/jakan.ts
+++ b/src/jakan.ts
@@ -38,10 +38,10 @@ class Jakan {
         return this.builder.build<JakanMisc>();
     }
 
-    // Returns a JakanUsers client. Won't cache requests.
+    // Returns a JakanUsers client.
     // You need to register an ClientID to use this. Please check Jakan README for more info.
-    forUsers(clientID: string): JakanUsers {
-        this.builder.setForUsers(clientID);
+    forUsers(): JakanUsers {
+        this.builder.setForUsers();
         return this.builder.build<JakanUsers>();
     }
 

--- a/src/response/responseTypes.ts
+++ b/src/response/responseTypes.ts
@@ -1,11 +1,9 @@
-import JakanSearch from "../clients/search/search";
-
 // A generic map for the "data" field of Jikan request responses.
 interface JakanData {
     // TODO: Map each request individually.
     // This will, of course, take a really long time.
     [key: string]: unknown;
-    mal_id: number;
+    mal_id?: number;
 }
 
 type JakanPaginationItems = {
@@ -20,18 +18,14 @@ type JakanPagination = {
     items: JakanPaginationItems;
 };
 
-interface JakanSeasonListResponse {
-    data: [];
-}
-
 type JakanQueryResponse = {
     data: JakanData[];
-    pagination: JakanPagination;
+    pagination?: JakanPagination;
 };
 
 type JakanIDResponse = {
     data: JakanData;
-    pagination: JakanPagination;
+    pagination?: JakanPagination;
 };
 
-export type { JakanQueryResponse, JakanIDResponse, JakanSeasonListResponse };
+export type { JakanQueryResponse, JakanIDResponse };

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -1,9 +1,38 @@
 import Jakan from "../src";
 import JakanUsers from "../src/clients/users/users";
 
+jest.setTimeout(10000);
+
 describe("JakanUsers", () => {
     test("should return a JakanUsers instance", () => {
         const client = new Jakan().withMemory().forUsers();
         expect(client).toBeInstanceOf(JakanUsers);
+    });
+    test("should return a user profile", async () => {
+        const client = new Jakan().withMemory().forUsers();
+        const user = await client.users("Lamarco");
+        expect(user).toHaveProperty("data");
+        const userData = user.data;
+        expect(userData).toHaveProperty("mal_id");
+    });
+    test("should return a user statistics using extra info parameter", async () => {
+        const client = new Jakan().withMemory().forUsers();
+        const user = await client.users("Lamarco", "statistics");
+        expect(user).toHaveProperty("data");
+    });
+    test("should return user search results", async () => {
+        const client = new Jakan().withMemory().forUsers();
+        const user = await client.usersSearch("Lamarco");
+        expect(user).toHaveProperty("data");
+        expect(user.data.length).toBeGreaterThan(0);
+    });
+    test("should return user search results with query parameters", async () => {
+        const client = new Jakan().withMemory().forUsers();
+        const user = await client.usersSearch({
+            q: "Lamarco",
+            gender: "male",
+        });
+        expect(user).toHaveProperty("data");
+        expect(user.data.length).toBeGreaterThan(0);
     });
 });

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -1,0 +1,5 @@
+import Jakan from "../src";
+
+describe("JakanUsers", () => {
+    test("should return a JakanUsers instance", () => {})
+});

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -1,5 +1,9 @@
 import Jakan from "../src";
+import JakanUsers from "../src/clients/users/users";
 
 describe("JakanUsers", () => {
-    test("should return a JakanUsers instance", () => {})
+    test("should return a JakanUsers instance", () => {
+        const client = new Jakan().withMemory().forUsers();
+        expect(client).toBeInstanceOf(JakanUsers);
+    });
 });


### PR DESCRIPTION
We now use Jikan's user endpoints. This implementation is way better than using the MAL client directly, 
This also removes the need for a ClientID.

Check commit history for more info.
Closes #4 